### PR TITLE
fix: 修复路由文件生成路径错误的问题 (#21)

### DIFF
--- a/annotation/ProcessAnnot.go
+++ b/annotation/ProcessAnnot.go
@@ -428,7 +428,9 @@ func genOutPut(outDir, modFile string) {
 
 	_genInfo.Tm = time.Now().Unix()
 	_data, _ := serializing.Encode(&_genInfo) // gob serialize 序列化
-	_path := path.Join(tools.GetCurrentDirectory(), utils.GetRouter)
+	// 使用 modFile 作为基础路径，确保路由文件生成在正确的位置
+	_routerDir := modFile + "/routers/"
+	_path := path.Join(_routerDir, "gen_router.data")
 	if !b {
 		tools.BuildDir(_path)
 	}


### PR DESCRIPTION
## 描述

修复 Issue #21：生成的路由文件位置不正确的问题。

## 问题

examples/main.go 编译执行之后，生成的路由文件（gen_router.data）和 main 平级，正确的应该是 routers 目录下。

## 修复

修改 annotation/ProcessAnnot.go 中 genOutPut 函数：



## 原因

原代码使用 GetCurrentDirectory() 获取当前执行目录，而不是项目根目录（go.mod 所在目录）。当从 examples/ 目录运行时，生成的路径会错误地放在 examples/ 目录下。

## 测试

修复后，无论从哪个目录运行 main.go，路由文件都会正确生成在项目根目录的 routers/ 目录下。