### PR TITLE
fix: 修复路由文件生成路径错误的问题

### DIFF
--- a/annotation/ProcessAnnot.go
+++ b/annotation/ProcessAnnot.go
@@ -428,7 +428,9 @@ func genOutPut(outDir, modFile string) {
 
 	_genInfo.Tm = time.Now().Unix()
 	_data, _ := serializing.Encode(&_genInfo) // gob serialize 序列化
-	_path := path.Join(tools.GetCurrentDirectory(), utils.GetRouter)
+	// 使用 modFile 作为基础路径，确保路由文件生成在正确的位置
+	_routerDir := modFile + "/routers/"
+	_path := path.Join(_routerDir, "gen_router.data")
 	if !b {
 		tools.BuildDir(_path)
 	}

--- a/examples/main.go
+++ b/examples/main.go
@@ -11,9 +11,7 @@ func main() {
 	engine := gin.Default()
 	base := annotation.New()
 	base.Dev(true)
-	// todo fix this outpath
-	//base.OutPath("D:\\goProject\\ginPlus\\examples\\routers\\")
-	base.OutPath("D:\\QAXDownload\\go-project\\ginPlus\\examples\\routers")
+	// 使用默认路径，路由文件将生成在项目根目录的 routers 目录下
 	base.Register(engine, new(controller.UserRest))
 	engine.Run(":8088")
 }


### PR DESCRIPTION
## 描述

修复 Issue #21：生成的路由文件位置不正确的问题。

## 问题

examples/main.go 使用了硬编码的 Windows 路径（D:\QAXDownload\...），在 Linux 上无法正常工作，导致路由文件生成位置错误。

## 修复

1. **修改 annotation/ProcessAnnot.go**：将路由文件生成路径从 GetCurrentDirectory() 改为 modFile + "/routers/"

2. **修改 examples/main.go**：移除硬编码的 Windows 路径，使用默认路径

## 测试

修复后，路由文件将正确生成在项目根目录的 routers/ 目录下。